### PR TITLE
runpy support

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+python_version = 3.8

--- a/smoketests/accept_twice_clobber.py
+++ b/smoketests/accept_twice_clobber.py
@@ -1,0 +1,7 @@
+import expecttest
+from expecttest import assert_expected_inline
+
+S1 = "a\nb"
+S2 = "a\nb\nc"
+
+assert_expected_inline(S2 if hasattr(expecttest, "_TEST2") else S1, """""")

--- a/smoketests/accept_twice_reload.py
+++ b/smoketests/accept_twice_reload.py
@@ -1,0 +1,10 @@
+import expecttest
+from expecttest import assert_expected_inline
+
+S1 = "a\nb"
+S2 = "a\nb\nc"
+
+if hasattr(expecttest, "_TEST1"):
+    assert_expected_inline(S1, """""")
+else:
+    assert_expected_inline(S2, """""")


### PR DESCRIPTION
Adds a new public API `expecttest.EDIT_HISTORY.reload_file(fn)` which indicates that you reloaded a file.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>
